### PR TITLE
Skip computed properties

### DIFF
--- a/Sources/SWONMacros/Decoding.swift
+++ b/Sources/SWONMacros/Decoding.swift
@@ -131,6 +131,10 @@ struct SWONDecodeMacro: MemberMacro {
         } else {
             // Parse struct fields
             for prop in properties {
+                // Skip computed properties
+                guard prop.bindings.allSatisfy({ !$0.isComputed }) else {
+                    continue
+                }
                 guard let field = prop.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
                     continue
                 }

--- a/Sources/SWONMacros/Encoding.swift
+++ b/Sources/SWONMacros/Encoding.swift
@@ -163,6 +163,10 @@ struct SWONEncodeMacro: MemberMacro {
         } else {
             // Struct fields
             for prop in properties {
+                // Skip computed properties
+                guard prop.bindings.allSatisfy({ !$0.isComputed }) else {
+                    continue
+                }
                 guard let field = prop.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
                     continue
                 }

--- a/Sources/SWONMacros/Helpers.swift
+++ b/Sources/SWONMacros/Helpers.swift
@@ -79,6 +79,12 @@ extension EnumDeclSyntax {
     }
 }
 
+extension PatternBindingSyntax {
+    var isComputed: Bool {
+        accessorBlock != nil
+    }
+}
+
 struct SWONMessage: DiagnosticMessage {
     let severity: DiagnosticSeverity = .note
     let message: String


### PR DESCRIPTION
The macros were trying to expand on computed properties, too. Skip them.