### PR TITLE
Handle internally labeled enum args

### DIFF
--- a/Sources/SWONMacros/Decoding.swift
+++ b/Sources/SWONMacros/Decoding.swift
@@ -66,8 +66,14 @@ struct SWONDecodeMacro: MemberMacro {
                                 isOptional = true
                             }
                             if let firstName = p.firstName {
-                                name = firstName.description
-                                parmAssignments.append("\(name): \(name)")
+                                if firstName.tokenKind == .wildcard,
+                                   let secondName = p.secondName {
+                                    name = secondName.description
+                                    parmAssignments.append("\(name)")
+                                } else {
+                                    name = firstName.description
+                                    parmAssignments.append("\(name): \(name)")
+                                }
                             } else {
                                 name = "_\(i)"
                                 parmAssignments.append(name)
@@ -83,8 +89,8 @@ struct SWONDecodeMacro: MemberMacro {
                                     """)
                             }
                             assignments.append("""
-                                    try dictResult.check("\(name) in \(el.name)")
-                                    \(mapItem(to: type, fieldName: "\(name) in \(el.name)", varName: "dict", nesting: 0, isOptional: isOptional))
+                                try dictResult.check("\(name) in \(el.name)")
+                                \(mapItem(to: type, fieldName: "\(name) in \(el.name)", varName: "dict", nesting: 0, isOptional: isOptional))
                                 }()
                                 """)
                         }

--- a/Sources/SWONMacros/Encoding.swift
+++ b/Sources/SWONMacros/Encoding.swift
@@ -65,19 +65,29 @@ struct SWONEncodeMacro: MemberMacro {
                         var parmVars: [(String, Bool)] = []
                         var parmAssignments: [String] = []
                         parms.enumerated().forEach { i, p in
-                            let name = p.firstName?.description ?? "_\(i)"
+                            let name: String
+                            if let firstName = p.firstName {
+                                if firstName.tokenKind == .wildcard,
+                                   let secondName = p.secondName {
+                                    name = secondName.description
+                                } else {
+                                    name = firstName.description
+                                }
+                            } else {
+                                name = "_\(i)"
+                            }
                             var type = p.type.decodedType(context: context)
                             var isOptional = false
                             if case .optional(let decodedType) = type {
                                 type = decodedType
                                 isOptional = true
                             }
-                            context.diagnose(
-                                Diagnostic(
-                                    node: Syntax(node),
-                                    message: SWONMessage(message: "CASE \(enumType) -> \(type) \(isOptional)")
-                                )
-                            )
+//                            context.diagnose(
+//                                Diagnostic(
+//                                    node: Syntax(node),
+//                                    message: SWONMessage(message: "CASE \(enumType) -> \(type) \(isOptional)")
+//                                )
+//                            )
                             parmVars.append((name, isOptional))
                             parmDeclarations.append("let \(name)")
                             parmAssignments.append(

--- a/Tests/SWONTests/ComplexStruct.swift
+++ b/Tests/SWONTests/ComplexStruct.swift
@@ -85,4 +85,5 @@ enum AssociatedEnum: Equatable, Codable {
     case multipleFlat(Int, Bool)
     case multipleKeyed(d: Double, b: Bool)
     case multipleMixed(d: Double, Bool?, foo: SubStruct)
+    case multipleUnnamed(named: Int, _ anon: Int)
 }


### PR DESCRIPTION
The wildcard in enum args was not handled properly, i.e., when the external name is unspecified (_) but the internal name is.