### PR TITLE
Build macro plugin as host-bound subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,16 @@
 cmake_minimum_required(VERSION 3.27)
-project(swon LANGUAGES Swift C)
-include(FetchContent)
+project(SWON LANGUAGES Swift C)
+include(ExternalProject)
 
-# Fetch the macros dependencies
-FetchContent_Declare(
-    SwiftSyntax
-    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG edbbad240dfcc4a9a791c1e4261f52fe08342e53
+# Build the macros plugin
+ExternalProject_Add(SWONMacrosProject
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWONMacros
+    INSTALL_COMMAND ""
 )
-FetchContent_MakeAvailable(SwiftSyntax)
+ExternalProject_Get_Property(SWONMacrosProject BINARY_DIR)
+set(MACRO_PLUGIN_DIR ${BINARY_DIR})
 
-# Build the macros with SwiftSyntax
-file(GLOB_RECURSE SWON_SWIFT_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWONMacros/*.swift
-)
-add_executable(SWONMacros ${SWON_SWIFT_SOURCES})
-target_link_libraries(SWONMacros PRIVATE
-    SwiftCompilerPlugin
-)
-
-# Build the macro impl with cJSON
+# Build the implementation with cJSON (Swift + C)
 add_library(SWON_C STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWON_C/swon.c
     ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWON_C/cJSON.c
@@ -27,19 +18,19 @@ add_library(SWON_C STATIC
 target_include_directories(SWON_C PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWON_C/include
 )
-
-# Build the macro glue with the C impl
 add_library(SWON STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWON/SWON.swift
 )
-add_dependencies(SWON SWONMacros)
 target_include_directories(SWON PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWON_C/include
 )
-target_compile_options(SWON PRIVATE
-    -load-plugin-executable "$<TARGET_FILE:SWONMacros>#SWONMacros"
-)
 target_link_libraries(SWON PRIVATE SWON_C)
+
+# Depend on macros plugin
+add_dependencies(SWON SWONMacrosProject)
+target_compile_options(SWON PRIVATE
+    -load-plugin-executable "${MACRO_PLUGIN_DIR}/SWONMacros#SWONMacros"
+)
 
 # Export interface
 add_library(SWONInterface INTERFACE)
@@ -49,7 +40,7 @@ target_include_directories(SWONInterface INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/Sources/SWON_C/include
 )
 target_compile_options(SWONInterface INTERFACE
-    -load-plugin-executable "$<TARGET_FILE:SWONMacros>#SWONMacros"
+    -load-plugin-executable "${MACRO_PLUGIN_DIR}/SWONMacros#SWONMacros"
 )
 target_link_libraries(SWONInterface INTERFACE SWON)
 

--- a/Sources/SWONMacros/CMakeLists.txt
+++ b/Sources/SWONMacros/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.27)
+project(SWONMacros LANGUAGES Swift)
+include(FetchContent)
+
+# Always build SWONMacros against the host machine
+
+# Fetch the macros dependencies
+FetchContent_Declare(
+    SwiftSyntax
+    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
+    GIT_TAG edbbad240dfcc4a9a791c1e4261f52fe08342e53
+)
+FetchContent_MakeAvailable(SwiftSyntax)
+
+# Build the macros with SwiftSyntax
+add_executable(SWONMacros
+    Decoding.swift
+    Encoding.swift
+    Helpers.swift
+    Macros.swift
+)
+target_link_libraries(SWONMacros PRIVATE SwiftCompilerPlugin)


### PR DESCRIPTION
To enforce host target even when cross-compiling, because the macro plugin must run on the host machine regardless of the target it's bound to. ExternalProject is a quick way to avoid target inheritance when cross-compiling.

E.g. when cross-compiling for Android on a macOS machine, the SWON macro plugin must be built for macOS, but the SWON implementation (based on cJSON) must be built for Android.